### PR TITLE
Subfolders not documented fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         else
           mkdir -p Documentation~
         fi
-        mv manual Documentation~/manual
+        sudo mv /manual /Documentation~/manual/
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -16,13 +16,13 @@ runs:
     - name: Move everything inside the manual/ folder.
       shell: bash
       run: |
+        mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv -v Documentation~ Documentation~/manual/
+          mv -v Documentation~ manual
         else
           mkdir -p Documentation~
-          mkdir -p manual
-          mv -v manual Documentation~/manual
         fi
+        mv -v manual Documentation~/manual
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -16,13 +16,11 @@ runs:
     - name: Move everything inside the manual/ folder.
       shell: bash
       run: |
-        mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv Documentation~ manual
+          mv Documentation~ Documentation~/manual
         else
-          mkdir -p Documentation~
+          mkdir -p Documentation~/manual
         fi
-        mv -v manual Documentation~/manual
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         else
           mkdir -p Documentation~
         fi
-        sudo mv /manual /Documentation~/manual/
+        sudo mv manual /Documentation~/manual/
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ runs:
       run: |
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
           mv Documentation~ manual
+          mkdir -p Documentation~
           mv manual Documentation~/manual
         else
           mkdir -p Documentation~/manual

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,11 @@ runs:
       run: |
         mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv -v Documentation~/* manual/
+          mv -v Documentation~ manual
         else
           mkdir -p Documentation~
         fi
-        sudo mv manual /Documentation~/manual/
+        mv -v manual /Documentation~/manual
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ runs:
       shell: bash
       run: |
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv Documentation~ manual
+          mv Documentation~/ manual/
           mkdir -p Documentation~
-          mv manual Documentation~/manual
+          mv manual/ Documentation~/manual/
         else
           mkdir -p Documentation~/manual
         fi

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv -v Documentation~ manual
+          mv -v Documentation~/ manual/
         else
           mkdir -p Documentation~
         fi

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         else
           mkdir -p Documentation~
         fi
-        mv -v manual Documentation~/manual
+        mv manual Documentation~/manual
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,8 @@ runs:
       shell: bash
       run: |
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv Documentation~ Documentation~/manual
+          mv Documentation~ manual
+          mv manual Documentation~/manual
         else
           mkdir -p Documentation~/manual
         fi

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv -v Documentation~/ manual/
+          mv Documentation~ manual
         else
           mkdir -p Documentation~
         fi

--- a/action.yml
+++ b/action.yml
@@ -146,7 +146,7 @@ runs:
                     {"src": "license", "files": ["*.md"], "dest": "license"},
                     {"src": "changelog", "files": ["*.md"], "dest": "changelog"},
                     {"src": "api", "files": ["*.yml", "index.md"], "dest": "api"},
-                    {"src": "manual", "files": ["*.md"], "dest": "manual"}
+                    {"src": "manual", "files": ["**/*.md"], "dest": "manual"}
                 ],
                 "resource": [{"files": ["manual/images/*"]}],
                 "template": ["default", "modern"],
@@ -211,7 +211,7 @@ runs:
     # Build docfx site through the Documentation~ folder
 
     - name: Dotnet Setup
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.x
     

--- a/action.yml
+++ b/action.yml
@@ -16,13 +16,13 @@ runs:
     - name: Move everything inside the manual/ folder.
       shell: bash
       run: |
-        mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv -v Documentation~/** manual/
+          mv -v Documentation~ Documentation~/manual/
         else
           mkdir -p Documentation~
+          mkdir -p manual
+          mv -v manual Documentation~/manual
         fi
-        mv -v manual Documentation~/manual
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -18,11 +18,11 @@ runs:
       run: |
         mkdir -p manual
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv -v Documentation~ manual
+          mv -v Documentation~/** manual/
         else
           mkdir -p Documentation~
         fi
-        mv -v manual /Documentation~/manual
+        mv -v manual Documentation~/manual
 
     # Generate pages, tables of contents, the docfx.json and anything the docfx needs.
 

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ runs:
       shell: bash
       run: |
         if [ -d Documentation~ ] && [ "$(ls -A Documentation~)" ]; then
-          mv Documentation~/ manual/
+          mv -v Documentation~/ manual/
           mkdir -p Documentation~
-          mv manual/ Documentation~/manual/
+          mv -v manual/ Documentation~/manual/
         else
           mkdir -p Documentation~/manual
         fi


### PR DESCRIPTION
This fix causes Documentation~/subfolders to be documented as well (small oversight).