### PR TITLE
update .NET version to 9.x

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,7 @@ runs:
     - name: Dotnet Setup
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.x
+        dotnet-version: 9.x
     
     - name: Dotnet Update
       shell: bash


### PR DESCRIPTION
docFX no longer supports dotnet 7, causing failed builds as it cant find the package. it produces the following error:

```
dotnet tool update -g docfx
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    package: { "name": "com.futurecolossal.easysettings", "displayName": "Easy Settings", "version": "0.3.5", "description": "Settings Helpers", "keywords": [ "files", "save", "load", "json" ], "category": "Utilities", "hideInEditor": false, "dependencies": { "com.futurecolossal.core": "0.8.2" } }
    DOTNET_ROOT: /usr/share/dotnet
    GH_TOKEN: ***
/tmp/816bc233-108d-4d21-8a83-16633c71ca7e/restore.csproj : error NU1202: Package docfx 2.78.2 is not compatible with net7.0 (.NETCoreApp,Version=v7.0) / any. Package docfx 2.78.2 supports:
/tmp/816bc233-108d-4d21-8a83-16633c71ca7e/restore.csproj : error NU1202:   - net8.0 (.NETCoreApp,Version=v8.0) / any
/tmp/816bc233-108d-4d21-8a83-16633c71ca7e/restore.csproj : error NU1202:   - net9.0 (.NETCoreApp,Version=v9.0) / any
Tool 'docfx' failed to update due to the following:
The tool package could not be restored.
Tool 'docfx' failed to install. This failure may have been caused by:

* You are attempting to install a preview release and did not use the --version option to specify the version.
* A package by this name was found, but it was not a .NET tool.
* The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
* You mistyped the name of the tool.
```

So I figured I'd bump it to 9.x as that should give the most future headroom.
thank you for your work on this!!